### PR TITLE
Fix bleed

### DIFF
--- a/pdf-structure.ts
+++ b/pdf-structure.ts
@@ -194,8 +194,18 @@ module PDFStructure {
       var maxHeight = Math.max.apply(null, breakBlocks.map(b => b.maxHeight()))
       var topViewBounds = [topXSpan[0],0,topXSpan[1], bottomOfBreak - maxHeight]
       var topPanel = new Panel(PanelType.TopHeader, topViewBounds)
-      var leftColumn = new Panel(PanelType.LeftColumn, [leftXSpan[0], bottomOfBreak, leftXSpan[1], page.view[3]])
-      var rightColumn = new Panel(PanelType.RightColumn, [rightXSpan[0], bottomOfBreak, rightXSpan[1], page.view[3]])
+      // mid-way of top of bottom columns and break
+      var topOfBottomColumn
+      if (leftBottomBlocks.length > 0 && rightBottomBlocks.length > 0) {
+        var leftTop = Math.min.apply(null, leftBottomBlocks.map(b => b.ySpan()[0]))
+        var rightTop = Math.min.apply(null, rightBottomBlocks.map(b => b.ySpan()[0]))
+        topOfBottomColumn = Math.max.apply(null, [leftTop, rightTop])
+      } else {
+        topOfBottomColumn = bottomOfBreak
+      }
+      var topBottomBreak = 0.5 * (bottomOfBreak +  topOfBottomColumn)
+      var leftColumn = new Panel(PanelType.LeftColumn, [leftXSpan[0], topBottomBreak, leftXSpan[1], page.view[3]])
+      var rightColumn = new Panel(PanelType.RightColumn, [rightXSpan[0], topBottomBreak, rightXSpan[1], page.view[3]])
       panelLayout = {type: PanelLayoutType.TopFullWidthTwoColumn, panels: [topPanel, leftColumn, rightColumn]}
     } else {
       var leftColumn = new Panel(PanelType.LeftColumn, [leftXSpan[0], 0, leftXSpan[1], page.view[3]])

--- a/pdf-structure.ts
+++ b/pdf-structure.ts
@@ -179,6 +179,15 @@ module PDFStructure {
       var rightXSpan = xSpanForBlocks(rightBottomBlocks)
     }
 
+    var leftBottom, rightBottom
+    if (leftBottomBlocks.length === 0 || rightBottomBlocks.length === 0) {
+      leftBottom = page.view[3]
+      rightBottom = page.view[3]
+    } else {
+      leftBottom = 0.5 * (page.view[3] +   Math.max.apply(null, leftBottomBlocks.map(b => b.ySpan()[1])))
+      rightBottom = 0.5 * (page.view[3] + Math.max.apply(null, rightBottomBlocks.map(b => b.ySpan()[1])))
+    }
+
     //debugger
     if (bestBreakScore > 0.2) {
       // HACK(aria42) Top of 1st page is generally title
@@ -204,12 +213,12 @@ module PDFStructure {
         topOfBottomColumn = bottomOfBreak
       }
       var topBottomBreak = 0.5 * (bottomOfBreak +  topOfBottomColumn)
-      var leftColumn = new Panel(PanelType.LeftColumn, [leftXSpan[0], topBottomBreak, leftXSpan[1], page.view[3]])
-      var rightColumn = new Panel(PanelType.RightColumn, [rightXSpan[0], topBottomBreak, rightXSpan[1], page.view[3]])
+      var leftColumn = new Panel(PanelType.LeftColumn, [leftXSpan[0], topBottomBreak, leftXSpan[1], leftBottom])
+      var rightColumn = new Panel(PanelType.RightColumn, [rightXSpan[0], topBottomBreak, rightXSpan[1], rightBottom])
       panelLayout = {type: PanelLayoutType.TopFullWidthTwoColumn, panels: [topPanel, leftColumn, rightColumn]}
     } else {
-      var leftColumn = new Panel(PanelType.LeftColumn, [leftXSpan[0], 0, leftXSpan[1], page.view[3]])
-      var rightColumn = new Panel(PanelType.RightColumn, [rightXSpan[0], 0, rightXSpan[1], page.view[3]])
+      var leftColumn = new Panel(PanelType.LeftColumn, [leftXSpan[0], 0, leftXSpan[1], leftBottom])
+      var rightColumn = new Panel(PanelType.RightColumn, [rightXSpan[0], 0, rightXSpan[1], rightBottom])
       panelLayout = {type: PanelLayoutType.TwoColumn, panels: [leftColumn, rightColumn]}
     }
     //console.info("page num: " + page.pageNumber)

--- a/sample.html
+++ b/sample.html
@@ -17,10 +17,11 @@
         var canvasElem = document.getElementById('pdfCanvas');
         var pdfViewer;
         StructuredPDFViewer.display({
-          pdfURL: "test-pdfs/openie-relation.pdf",
+          pdfURL: "test-pdfs/openie.pdf",
           canvasElem: canvasElem
         }).then(function(viewer)  {
           pdfViewer = viewer;
+          window.pdfViewer = viewer;
           var sections = viewer.pdfData.sections;
           var select = document.getElementsByTagName('select')[0]
           sections.forEach(function(section, idx) {


### PR DESCRIPTION
I'd review the commits separately. Two fixes
- In the case of 3-panel layout, don't use the bottom of the top header, pick the point between the top of the columns and the bottom of the top header
- Crop the bottom of the left, right column to kill the straddler footers. 
