### PR TITLE
A few tweaks to panel cropping.

### DIFF
--- a/pdf-structure.ts
+++ b/pdf-structure.ts
@@ -184,8 +184,18 @@ module PDFStructure {
       leftBottom = page.view[3]
       rightBottom = page.view[3]
     } else {
-      leftBottom = 0.5 * (page.view[3] +   Math.max.apply(null, leftBottomBlocks.map(b => b.ySpan()[1])))
-      rightBottom = 0.5 * (page.view[3] + Math.max.apply(null, rightBottomBlocks.map(b => b.ySpan()[1])))
+      // Add 5 pixels to ensrue we don't cut off descenders
+      leftBottom = Math.max.apply(null, leftBottomBlocks.map(b => b.ySpan()[1])) + 5
+      rightBottom = Math.max.apply(null, rightBottomBlocks.map(b => b.ySpan()[1])) + 5
+    }
+
+    var topOfBottomColumn
+    if (leftBottomBlocks.length > 0 && rightBottomBlocks.length > 0) {
+      var leftTop = Math.min.apply(null, leftBottomBlocks.map(b => b.ySpan()[0]))
+      var rightTop = Math.min.apply(null, rightBottomBlocks.map(b => b.ySpan()[0]))
+      topOfBottomColumn = Math.max.apply(null, [leftTop, rightTop])
+    } else if(bestBreakScore > 0.2) {
+      topOfBottomColumn = sortedHeights[bestBreakIdx]
     }
 
     //debugger
@@ -212,13 +222,20 @@ module PDFStructure {
       } else {
         topOfBottomColumn = bottomOfBreak
       }
-      var topBottomBreak = 0.5 * (bottomOfBreak +  topOfBottomColumn)
+      // 5 pixels makes sure we don't cut off ascenders
+      var topBottomBreak = topOfBottomColumn - 5;
       var leftColumn = new Panel(PanelType.LeftColumn, [leftXSpan[0], topBottomBreak, leftXSpan[1], leftBottom])
       var rightColumn = new Panel(PanelType.RightColumn, [rightXSpan[0], topBottomBreak, rightXSpan[1], rightBottom])
       panelLayout = {type: PanelLayoutType.TopFullWidthTwoColumn, panels: [topPanel, leftColumn, rightColumn]}
     } else {
-      var leftColumn = new Panel(PanelType.LeftColumn, [leftXSpan[0], 0, leftXSpan[1], leftBottom])
-      var rightColumn = new Panel(PanelType.RightColumn, [rightXSpan[0], 0, rightXSpan[1], rightBottom])
+      var top = 0;
+      if (leftBottomBlocks.length > 0 && rightBottomBlocks.length > 0) {
+        var leftTop = Math.min.apply(null, leftBottomBlocks.map(b => b.ySpan()[0]))
+        var rightTop = Math.min.apply(null, rightBottomBlocks.map(b => b.ySpan()[0]))
+        top = Math.max.apply(null, [leftTop, rightTop])
+      }
+      var leftColumn = new Panel(PanelType.LeftColumn, [leftXSpan[0], top, leftXSpan[1], leftBottom])
+      var rightColumn = new Panel(PanelType.RightColumn, [rightXSpan[0], top, rightXSpan[1], rightBottom])
       panelLayout = {type: PanelLayoutType.TwoColumn, panels: [leftColumn, rightColumn]}
     }
     //console.info("page num: " + page.pageNumber)

--- a/pdf-structure.ts
+++ b/pdf-structure.ts
@@ -184,9 +184,10 @@ module PDFStructure {
       leftBottom = page.view[3]
       rightBottom = page.view[3]
     } else {
-      // Add 5 pixels to ensrue we don't cut off descenders
-      leftBottom = Math.max.apply(null, leftBottomBlocks.map(b => b.ySpan()[1])) + 5
-      rightBottom = Math.max.apply(null, rightBottomBlocks.map(b => b.ySpan()[1])) + 5
+      // Add 5 pixels for descenders, and another 15 arbitrarily as the bottom crop seems
+      // to be consistently tighter
+      leftBottom = Math.max.apply(null, leftBottomBlocks.map(b => b.ySpan()[1])) + 15
+      rightBottom = Math.max.apply(null, rightBottomBlocks.map(b => b.ySpan()[1])) + 15
     }
 
     var topOfBottomColumn

--- a/pdf-viewer.ts
+++ b/pdf-viewer.ts
@@ -117,32 +117,21 @@ module StructuredPDFViewer {
       canvasScale(canvasParentWidth, viewport.height * this.viewportScale);
 
       const canvasCtx = canvas.getContext('2d')
-      const horizStrech = dpiScale
-      const verticStrech = dpiScale
       const panelWidthInCanvas = panel.width() * this.viewportScale * dpiScale
 
       this.panelSkew = canvas.width / panelWidthInCanvas
 
-      const dx = - this.panelSkew * horizStrech * this.viewportScale * panel.bounds[0];
-      const dy = - this.panelSkew * verticStrech * this.viewportScale * panel.bounds[1];
+      const dx = - this.panelSkew * dpiScale * this.viewportScale * panel.bounds[0];
+      const dy = - this.panelSkew * dpiScale * this.viewportScale * panel.bounds[1];
 
-      const adjustedPanelHeight = panel.height() * this.panelSkew + dy / dpiScale;
-      let scaledHeight = viewport.height * this.panelSkew + dy / dpiScale;
-      if (adjustedPanelHeight < scaledHeight) {
-        scaledHeight = adjustedPanelHeight;
-      }
-
-      let scaledWidth = viewport.width * this.panelSkew;
-      if (canvasParentWidth < scaledWidth) {
-        scaledWidth = canvasParentWidth;
-      }
-      canvasScale(scaledWidth, scaledHeight)
+      const adjustedPanelHeight = panel.height() * this.viewportScale * this.panelSkew;
+      canvasScale(canvasParentWidth, adjustedPanelHeight)
 
       canvasCtx.setTransform(
-        horizStrech * this.panelSkew,
+        dpiScale * this.panelSkew,
         0,
         0,
-        verticStrech * this.panelSkew,
+        dpiScale * this.panelSkew,
         dx,
         dy
       )
@@ -155,7 +144,7 @@ module StructuredPDFViewer {
       renderPromise.then(ignore => {
         if (false && panel.type == PDFStructure.PanelType.TopHeader) {
           canvasCtx.globalAlpha = 0.1
-          var panelHeight = this.panelSkew * verticStrech * this.viewportScale * panel.height()
+          var panelHeight = this.panelSkew * dpiScale * this.viewportScale * panel.height()
           canvasCtx.fillStyle="black"
           canvasCtx.fillRect(0,0,canvas.width,canvas.height-panelHeight)
           //debugger

--- a/pdf-viewer.ts
+++ b/pdf-viewer.ts
@@ -44,7 +44,7 @@ module StructuredPDFViewer {
       );
     }
 
-    jumpToSection(section: PDFStructure.SectionData): Promise<PDFPageProxy> {
+    jumpToSection(section: PDFStructure.SectionData): Promise<number> {
       this.pageIdx = section.pageIdx
       var pd = this.pdfData.pages[this.pageIdx]
       var sectionHeader = section.contentHeader
@@ -58,7 +58,9 @@ module StructuredPDFViewer {
       var dy = this.viewportScale * this.panelSkew * (sectionY - panelY)
       var scrollTop = dy - (this.displayParams.sectionJumpVerticalPad || 40)
       this.displayParams.scrollParent.scrollTop = scrollTop
-      return renderPromise
+      return renderPromise.then(() => {
+        return dy;
+      });
     }
 
     panel(pageIdx: number, panelIdx: number): PDFStructure.Panel {


### PR DESCRIPTION
- Aggressively crop with a small hard-coded value for handling ascenders / descenders.
- Always set the height to the panel height, don't worry about aspect ratio (it _should_ be maintained by panel dimensions).
- Apply mechanism for determining the top to the two-column layout as well as the top + two column layout.

@aria42 
